### PR TITLE
Change padding to make Base36TimeKeys sortable

### DIFF
--- a/src/Helpers/Base36TimeKey.php
+++ b/src/Helpers/Base36TimeKey.php
@@ -26,7 +26,7 @@ class Base36TimeKey
     $time = floor($time);
 
     $return = base_convert(str_pad($time, 13, '0', STR_PAD_LEFT), 10, 36);
-    return str_pad(strtoupper($return), 9, '=', STR_PAD_RIGHT);
+    return str_pad(strtoupper($return), 9, '0', STR_PAD_LEFT);
   }
 
   public static function getMsTime($timeKey)


### PR DESCRIPTION
Made Base36TimeKey sortable by padding with zero at the start rather than equals at the end
